### PR TITLE
Fix build on ESP32 variants with only 2 UARTs (S2/C3)

### DIFF
--- a/components/aurora_monitor/aurora_monitor.cpp
+++ b/components/aurora_monitor/aurora_monitor.cpp
@@ -2,9 +2,14 @@
 #include "aurora_monitor.h"
 #include "esphome/core/log.h"
 
-
 #if defined(USE_ESP32)
+#include "soc/soc_caps.h"
+// ESP32-S2 and C3 only have 2 UARTs, so Serial2 does not exist there
+#if SOC_UART_NUM > 2
 #define AURORA_SERIAL Serial2
+#else
+#define AURORA_SERIAL Serial1
+#endif
 #elif defined(USE_ESP8266)
 #define AURORA_SERIAL Serial
 #else


### PR DESCRIPTION
The hardcoded Serial2 fails to compile on ESP32-S2 and C3, which only have two UARTs ('Serial2' was not declared in this scope). Select the UART via SOC_UART_NUM: Serial2 where available, Serial1 otherwise.

Verified on lolin_s2_mini (ESP32-S2) with ESPHome 2026.6.4 / arduino-esp32 3.3.9.